### PR TITLE
Change references field type to Array in form schema (resolves #18)

### DIFF
--- a/models/projects.js
+++ b/models/projects.js
@@ -1,5 +1,11 @@
 const mongoose = require('mongoose')
 
+const referencesSchema = new mongoose.Schema( {
+  name: {
+    type: String,
+  },
+})
+
 const xColumnsSchema = new mongoose.Schema( {
     name: {
       type: String,
@@ -22,9 +28,7 @@ const formSchema = new mongoose.Schema({
     description: {
       type: String,
     },
-    references: {
-      type: String,
-    },
+    references: [referencesSchema],
     xColumns: [xColumnsSchema],
     yColumns: [yColumnsSchema],
 })


### PR DESCRIPTION
# What does this PR do? 
Changes the "references"-field in the form schema from String to an Array. This allows users to add multiple references to their forms.

# How to test this PR:

1. start MongoDB, e.g. using docker: ```docker run -p 27017:27017 --name mongodb -d mongo``` and ```export DATABASE_URL="mongodb://localhost:27017/test"```
2. start the backend server, e.g. using: ```npm start```
3. create a project with a form which contains multiple references, eg.: ```curl --location 'http://localhost:3000/project' --header 'Content-Type: application/json' --data '{ "name": "references test", "forms": [ { "name": "form with references", "references": [ { "name": "reference 1" }, { "name": "reference 2" } ] } ] }'```
4. check for the references by retrieving the form: ```curl --location 'http://localhost:3000/project/642d7c109892c30a99d9db21/form/642d7c109892c30a99d9db22'```

# Anything else the reviewer should know about?
Nothing
