### PR TITLE
Set name fields as required in project and form schema (resolves #19)

### DIFF
--- a/models/projects.js
+++ b/models/projects.js
@@ -3,12 +3,14 @@ const mongoose = require('mongoose')
 const referencesSchema = new mongoose.Schema( {
   name: {
     type: String,
+    required: true,
   },
 })
 
 const xColumnsSchema = new mongoose.Schema( {
     name: {
       type: String,
+      required: true,
     },
     range: {
       type: Boolean,
@@ -18,12 +20,14 @@ const xColumnsSchema = new mongoose.Schema( {
 const yColumnsSchema = new mongoose.Schema( {
     name: {
       type: String,
+      required: true,
     },
 })
 
 const formSchema = new mongoose.Schema({
     name: {
         type: String,
+        required: true,
     },
     description: {
       type: String,
@@ -36,6 +40,7 @@ const formSchema = new mongoose.Schema({
 const projectsSchema = new mongoose.Schema({
     name: {
         type: String,
+        required: true,
     },
     forms: [formSchema],
 })


### PR DESCRIPTION
# What does this PR do? 
Set "name" fields as required in all schemas. It makes sense to only include the "name" fields, since all other fields can be edited in the form editor at a later time.

# How to test this PR:

1. start MongoDB, e.g. using docker: ```docker run -p 27017:27017 --name mongodb -d mongo``` and ```export DATABASE_URL="mongodb://localhost:27017/test"```
2. start the backend server, e.g. using: ```npm start```
3. try to create a project without a name , eg.: ```curl --location 'http://localhost:3000/project' --header 'Content-Type: application/json' --data '{ "forms": [ { "name": "test form" } ] }'```, this should result in a ValidationError. The same goes for creating a form without a name.
4. create a project with a name to make sure it still works: ```curl --location 'http://localhost:3000/project' --header 'Content-Type: application/json' --data '{ "name": "validation test", "forms": [ { "name": "test form" } ] }'```

# Anything else the reviewer should know about?

