### PR TITLE
Add endpoint to delete forms

### DIFF
--- a/controllers/form.js
+++ b/controllers/form.js
@@ -57,8 +57,33 @@ const updateForm = asyncHandler(async (req, res) => {
   res.status(200).json(updatedForm)
 })
 
+const deleteForm = asyncHandler(async (req, res) => {
+
+  const projectId = req.params.pid
+  const formId = req.params.id
+
+  const project = await Project.findById(projectId)
+  if (!project) {
+    res.status(400)
+    throw new Error("project not found")
+  }
+
+  const form = await project.forms.id(formId)
+  if (!form) {
+    res.status(400)
+    throw new Error("form not found")
+  }
+
+  const formWithIdIndex = project.forms.findIndex((obj) => obj.id === formId);
+  project.forms.splice(formWithIdIndex, 1);
+  const deletedForm = await project.save();
+
+  res.status(200).json(deletedForm)
+})
+
 module.exports = {
     getForm,
     createForm,
     updateForm,
+    deleteForm,
 }

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -12,6 +12,7 @@ const {
     getForm,
     createForm,
     updateForm,
+    deleteForm,
 } = require('../controllers/form')
 
 
@@ -19,6 +20,6 @@ router.route("/").get(getProjects).post(createProject)
 router.route("/:id").get(getProjectByID).put(updateProject).delete(deleteProject)
 
 router.route("/:pid/form").post(createForm)
-router.route("/:pid/form/:id").get(getForm).put(updateForm)
+router.route("/:pid/form/:id").get(getForm).put(updateForm).delete(deleteForm)
 
 module.exports = router;


### PR DESCRIPTION
# What does this PR do? 
Creates an API endpoint that allows the deletion of forms.

# How to test this PR:

1. start MongoDB, e.g. using docker: ```docker run -p 27017:27017 --name mongodb -d mongo``` and ```export DATABASE_URL="mongodb://localhost:27017/test"```
2. start the backend server, e.g. using: ```npm start```
3. create a project with one or multiple forms, eg.: ```curl --location 'http://localhost:3000/project' --header 'Content-Type: application/json' --data '{ "name": "form deletion test", "forms": [ { "name": "form to be stay" }, { "name": "form to be deleted" } ] }'```
4. delete a form, eg.: ```curl --location --request DELETE 'http://localhost:3000/project/6445e83afb67929adbf055db/form/6445e83afb67929adbf055dc'```
5. check that the form was deleted: ```curl --location 'http://localhost:3000/project/6445e83afb67929adbf055db/form/6445e83afb67929adbf055dc'```, this should result in a "form not found" error
6. it can also be checked by looking at all forms of the project: ```curl --location 'http://localhost:3000/project/6445e83afb67929adbf055db'```

# Anything else the reviewer should know about?

