### PR TITLE
Build and run mongodb locally using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+docker_clean:
+	-docker stop cactus_mongodb
+	-docker rm cactus_mongodb
+	-docker rmi cactus/mongodb
+
+docker_build:
+	docker build -f cactus_mongo_db/Dockerfile -t cactus/mongodb .
+	echo "`docker images | grep cactus`"
+
+docker_run: docker_clean docker_build
+	docker run -d -p 27017:27017 --name cactus_mongodb cactus/mongodb
+	echo "Point your DB client to localhost:27017 to connect to this DB"
+
+.PHONY: docker_run docker_build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ The backend for Project Cactus
 
 ## Running the app while developing
 
+
+*Step 1*: Start the database
+
+To start the DB you can follow the [instructions in Confluene](https://oregonstate-innovationlab.atlassian.net/wiki/spaces/VOVA/pages/61145089/Docker+and+MongoDB).
+
+Or you can use the Makefile. 
+
+In a terminal run `make docker_run`. That will rebuild and run the mongodb docker image.
+
+Running `docker ps` will show a running mongodb container.
+
+```bash
+CONTAINER ID   IMAGE            COMMAND                  CREATED         STATUS         PORTS                      NAMES
+c7e14c84ed84   cactus/mongodb   "docker-entrypoint.s…"   3 minutes ago   Up 3 minutes   0.0.0.0:27017->27017/tcp   cactus_mongodb
+```
+
+*Step 2*: Start the backend
+
+
+```bash
+
 Use the following to run this app with auto restarts on changes:
 npm start
 

--- a/cactus_mongo_db/Dockerfile
+++ b/cactus_mongo_db/Dockerfile
@@ -1,0 +1,8 @@
+FROM mongo
+
+RUN apt-get update
+RUN apt-get -y install vim
+
+# Run with -p 27017:27017 in order to connect your DB client
+# to this running container.
+EXPOSE 27017


### PR DESCRIPTION
# What does this PR do? 

Creates a make target to rebuild and run a MongoDB container.


# How to test this PR:

run `make docker_run`. You should see the following:

1 - a docker image name `cactus/mongodb`. That's the image you just built
2 - a running docker container `cactus_mongodb`. 

# Anything else the reviewer should know about?

