### PR TITLE
Revert references field type from array to string in form schema

### DIFF
--- a/models/projects.js
+++ b/models/projects.js
@@ -1,12 +1,5 @@
 const mongoose = require('mongoose')
 
-const referencesSchema = new mongoose.Schema( {
-  name: {
-    type: String,
-    required: true,
-  },
-})
-
 const xColumnsSchema = new mongoose.Schema( {
     name: {
       type: String,
@@ -32,7 +25,9 @@ const formSchema = new mongoose.Schema({
     description: {
       type: String,
     },
-    references: [referencesSchema],
+    references: {
+      type: String,
+    },
     xColumns: [xColumnsSchema],
     yColumns: [yColumnsSchema],
 })


### PR DESCRIPTION
# What does this PR do? 
Reverts the field type change of the references field in the form schema. The references field will now again be a string.

# How to test this PR:

1. start the database and the server, following the instructions in README.md
2. create a project with a form which contains references, eg.: ```curl --location 'http://localhost:3000/project' --header 'Content-Type: application/json' --data '{ "name": "references test", "forms": [ { "name": "form with references", "references": "name 1, name 2" } ] }'```
3. check for the references by retrieving the form: ```curl --location 'http://localhost:3000/project/642d7c109892c30a99d9db21/form/642d7c109892c30a99d9db22'```

# Anything else the reviewer should know about?

